### PR TITLE
Use safe AST-based evaluation for expressions

### DIFF
--- a/tests/test_eval_expr.py
+++ b/tests/test_eval_expr.py
@@ -1,0 +1,17 @@
+import math
+import pytest
+from nagare_interpreter import eval_expr
+
+
+def test_arithmetic_expression():
+    assert eval_expr("x + y * 2 - 3", 3, 4) == 3 + 4 * 2 - 3
+
+
+def test_trigonometric_functions():
+    result = eval_expr("sin(x) + cos(y)", math.pi / 2, 0)
+    assert result == pytest.approx(2.0)
+
+
+def test_rejects_unsafe_constructs():
+    with pytest.raises(ValueError):
+        eval_expr("__import__('os').system('echo unsafe')", 0, 0)


### PR DESCRIPTION
## Summary
- Parse expressions with `ast` and evaluate only a whitelist of safe nodes and math functions
- Add unit tests covering arithmetic, trigonometric evaluation, and rejecting unsafe constructs

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c51441b883288829cfb659ce4ad8