### PR TITLE
Add tests for zone parsing and run actions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on sys.path so tests can import modules
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/fixtures/display_and_finish.nagare
+++ b/tests/fixtures/display_and_finish.nagare
@@ -1,0 +1,13 @@
+BEGIN {
+  program prog { x + 1, y }
+}
+
+ZONES {
+  msg { Ellipse((1, 0), 0.5, 0.5) }
+  end { Ellipse((2, 0), 0.5, 0.5) }
+}
+
+EXECUTE {
+  prog<msg> { display "Hello zone" }
+  prog<end> { finish }
+}

--- a/tests/fixtures/multiple_zones.nagare
+++ b/tests/fixtures/multiple_zones.nagare
@@ -1,0 +1,10 @@
+BEGIN {
+  program p { x, y }
+}
+
+ZONES {
+  zone1 { Ellipse((0, 0), 1, 2) }
+  zone2 { Ellipse((1, 1), 3, 4) }
+}
+
+EXECUTE {}

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from nagare_interpreter import parse_zones, parse_script, run
+
+
+def test_parse_zones_multiple_definitions():
+    path = Path(__file__).parent / "fixtures" / "multiple_zones.nagare"
+    content = path.read_text()
+    zones = parse_zones(content)
+    assert [z.name for z in zones] == ["zone1", "zone2"]
+    z1, z2 = zones
+    assert (z1.cx, z1.cy, z1.a, z1.b) == (0.0, 0.0, 1.0, 2.0)
+    assert (z2.cx, z2.cy, z2.a, z2.b) == (1.0, 1.0, 3.0, 4.0)
+
+
+def test_run_triggers_display_and_finish(capsys):
+    path = Path(__file__).parent / "fixtures" / "display_and_finish.nagare"
+    prog_x, prog_y, zones = parse_script(str(path))
+    run(prog_x, prog_y, zones)
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured == ["Hello zone", "Finished at step 2"]


### PR DESCRIPTION
## Summary
- add fixtures and tests for zone parsing
- verify run triggers display and finish actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d28cde8a08328995b858751558579