### PR TITLE
Raise error on unknown zone in parse_execute

### DIFF
--- a/nagare_interpreter.py
+++ b/nagare_interpreter.py
@@ -112,7 +112,7 @@ def parse_execute(src: str, zones: Dict[str, Zone]) -> None:
     )
     for zone_name, action_block, msg in exec_pattern.findall(src):
         if zone_name not in zones:
-            continue
+            raise ValueError(f"Unknown zone: {zone_name}")
         if action_block.startswith('display'):
             zones[zone_name].action = ('display', msg)
         else:

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from nagare_interpreter import parse_zones, parse_script, run
+from nagare_interpreter import parse_zones, parse_script, run, parse_execute
 
 
 def test_parse_zones_multiple_definitions():
@@ -21,3 +21,9 @@ def test_run_triggers_display_and_finish(capsys):
     run(prog_x, prog_y, zones)
     captured = capsys.readouterr().out.strip().splitlines()
     assert captured == ["Hello zone", "Finished at step 2"]
+
+
+def test_parse_execute_raises_for_unknown_zone():
+    src = "EXECUTE { prog<missing> { display \"hello\" } }"
+    with pytest.raises(ValueError, match="missing"):
+        parse_execute(src, {})


### PR DESCRIPTION
## Summary
- raise `ValueError` when `parse_execute` encounters an undefined zone
- add unit test covering unknown zone case

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689de3d6c85c8328b4d8c5b0b6d6c32c