### PR TITLE
Handle invalid zone parameters in simulator

### DIFF
--- a/tests/test_simulator_app.py
+++ b/tests/test_simulator_app.py
@@ -1,0 +1,36 @@
+import pytest
+
+from webapp.app import app
+
+
+@pytest.fixture
+def client():
+    app.config.update(TESTING=True)
+    with app.test_client() as client:
+        yield client
+
+
+def _base_payload():
+    return {
+        "vectorField": {"fx": "0", "fy": "0"},
+        "entities": [{"id": "entity-0", "x": 0, "y": 0}],
+        "settings": {"duration": 1, "dt": 1},
+    }
+
+
+@pytest.mark.parametrize(
+    "zone_payload, expected_fragment",
+    [
+        ({"type": "circle", "r": "not-a-number"}, "invalid value for 'r'"),
+        ({"type": "rect", "w": "oops", "h": 1}, "invalid value for 'w'"),
+    ],
+)
+def test_simulate_rejects_non_numeric_zone_parameters(client, zone_payload, expected_fragment):
+    payload = _base_payload()
+    payload["zones"] = [zone_payload]
+
+    response = client.post("/simulate", json=payload)
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert expected_fragment in data["error"]

--- a/webapp/simulator.py
+++ b/webapp/simulator.py
@@ -151,7 +151,13 @@ def _parse_zones(raw_zones: Iterable[Dict]) -> List[Zone]:
         params = {}
         for key in ("cx", "cy", "r", "w", "h"):
             if key in raw:
-                params[key] = float(raw[key])
+                value = raw[key]
+                try:
+                    params[key] = float(value)
+                except (TypeError, ValueError) as exc:
+                    raise SimulationError(
+                        f"Zone '{label}' has invalid value for '{key}': {value!r}."
+                    ) from exc
         if zone_type == "circle" and params.get("r", 0.0) <= 0:
             raise SimulationError(f"Circle zone '{label}' requires a positive radius.")
         if zone_type == "rect" and (params.get("w", 0.0) <= 0 or params.get("h", 0.0) <= 0):


### PR DESCRIPTION
## Summary
- raise SimulationError when zone parameters fail to cast to floats
- add simulator API tests verifying invalid zone dimensions return 400 responses

## Testing
- pytest tests/test_simulator_app.py

------
https://chatgpt.com/codex/tasks/task_e_69020d06735083289f24beea877b42a8