### PR TITLE
Ensure simulator uses full duration for final frame

### DIFF
--- a/tests/test_webapp_simulator.py
+++ b/tests/test_webapp_simulator.py
@@ -1,0 +1,18 @@
+import pytest
+
+from webapp.simulator import run_simulation
+
+
+def test_run_simulation_aligns_final_time_for_partial_step():
+    payload = {
+        "vectorField": {"fx": "0", "fy": "0"},
+        "zones": [],
+        "entities": [{"id": "entity-1", "x": 0.0, "y": 0.0}],
+        "settings": {"duration": 1.0, "dt": 0.6},
+    }
+
+    result = run_simulation(payload)
+    times = [frame["time"] for frame in result["frames"]]
+
+    assert times == pytest.approx([0.0, 0.6, 1.0])
+    assert times[-1] == pytest.approx(1.0)

--- a/webapp/simulator.py
+++ b/webapp/simulator.py
@@ -199,7 +199,8 @@ def run_simulation(payload: Dict) -> Dict:
     zones = sim_input.zones
     entities = [Entity(entity.entity_id, entity.x, entity.y) for entity in sim_input.entities]
     dt = sim_input.settings.dt
-    steps = int(sim_input.settings.duration / dt)
+    duration = sim_input.settings.duration
+    epsilon = 1e-9
 
     events: List[Dict] = []
     frames: List[Dict] = []
@@ -207,13 +208,13 @@ def run_simulation(payload: Dict) -> Dict:
     zone_membership: Dict[Tuple[str, str], bool] = {}
 
     t = 0.0
-    for step in range(steps + 1):
+    while True:
         frame_entities = []
         for entity in entities:
             frame_entities.append({"id": entity.entity_id, "x": entity.x, "y": entity.y})
         frames.append({"time": t, "entities": frame_entities})
 
-        if step == steps:
+        if duration - t <= epsilon:
             break
 
         for entity in entities:
@@ -233,6 +234,13 @@ def run_simulation(payload: Dict) -> Dict:
                 else:
                     zone_membership[key] = inside
 
+        remaining = max(duration - t, 0.0)
+        step_dt = dt if remaining - dt > epsilon else remaining
+        next_t = t + step_dt
+        if next_t > duration - epsilon:
+            next_t = duration
+            step_dt = next_t - t
+
         for entity in entities:
             try:
                 dx = fx(entity.x, entity.y, t)
@@ -243,9 +251,9 @@ def run_simulation(payload: Dict) -> Dict:
             if not (math.isfinite(dx) and math.isfinite(dy)):
                 raise SimulationError("Vector field produced non-finite values.")
 
-            entity.x += dx * dt
-            entity.y += dy * dt
+            entity.x += dx * step_dt
+            entity.y += dy * step_dt
 
-        t += dt
+        t = next_t
 
     return {"frames": frames, "events": events}

--- a/webapp/simulator.py
+++ b/webapp/simulator.py
@@ -214,9 +214,6 @@ def run_simulation(payload: Dict) -> Dict:
             frame_entities.append({"id": entity.entity_id, "x": entity.x, "y": entity.y})
         frames.append({"time": t, "entities": frame_entities})
 
-        if duration - t <= epsilon:
-            break
-
         for entity in entities:
             for zone in zones:
                 inside = zone.contains(entity.x, entity.y)
@@ -233,6 +230,9 @@ def run_simulation(payload: Dict) -> Dict:
                     })
                 else:
                     zone_membership[key] = inside
+
+        if duration - t <= epsilon:
+            break
 
         remaining = max(duration - t, 0.0)
         step_dt = dt if remaining - dt > epsilon else remaining


### PR DESCRIPTION
## Summary
- adjust the simulation loop to continue until the configured duration is reached
- align the final frame timestamp with the requested duration even when the time step does not divide evenly
- add regression coverage for non-divisible duration values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69020d099ab08328a8ff9149dd60de0a