### PR TITLE
Add AST and expression guardrails for simulator expressions

### DIFF
--- a/tests/test_webapp_simulator.py
+++ b/tests/test_webapp_simulator.py
@@ -1,6 +1,6 @@
 import pytest
 
-from webapp.simulator import run_simulation
+from webapp.simulator import SimulationError, _compile_expression, run_simulation
 
 
 def test_run_simulation_aligns_final_time_for_partial_step():
@@ -16,3 +16,21 @@ def test_run_simulation_aligns_final_time_for_partial_step():
 
     assert times == pytest.approx([0.0, 0.6, 1.0])
     assert times[-1] == pytest.approx(1.0)
+
+
+def test_compile_expression_rejects_oversized_ast():
+    expr = "+".join(["x"] * 260)
+
+    with pytest.raises(SimulationError, match="too complex"):
+        _compile_expression(expr)
+
+
+@pytest.mark.parametrize("expr", ["2**1000", "pow(x, 2, 3, 4, 5)"])
+def test_compile_expression_rejects_large_exponent_and_too_many_call_args(expr):
+    with pytest.raises(SimulationError):
+        _compile_expression(expr)
+
+
+def test_compile_expression_rejects_large_numeric_literal():
+    with pytest.raises(SimulationError, match="Numeric literal is too large"):
+        _compile_expression("x + 1000000000000")

--- a/webapp/simulator.py
+++ b/webapp/simulator.py
@@ -45,7 +45,6 @@ _ALLOWED_NODES = (
     ast.Call,
     ast.BinOp,
     ast.UnaryOp,
-    ast.Num,
     ast.Name,
     ast.Load,
     ast.Add,
@@ -59,6 +58,11 @@ _ALLOWED_NODES = (
     ast.Constant,
 )
 
+_MAX_AST_NODE_COUNT = 200
+_MAX_NUMERIC_LITERAL_MAGNITUDE = 1_000_000
+_MAX_POW_EXPONENT = 100
+_MAX_CALL_ARGUMENT_COUNT = 4
+
 
 def _compile_expression(expr: str) -> Callable[[float, float, float], float]:
     if not expr or not expr.strip():
@@ -69,12 +73,39 @@ def _compile_expression(expr: str) -> Callable[[float, float, float], float]:
     except SyntaxError as exc:
         raise SimulationError(f"Invalid expression '{expr}': {exc.msg}") from exc
 
-    for node in ast.walk(tree):
+    nodes = list(ast.walk(tree))
+    if len(nodes) > _MAX_AST_NODE_COUNT:
+        raise SimulationError(
+            f"Expression is too complex; limit it to {_MAX_AST_NODE_COUNT} syntax nodes or fewer."
+        )
+
+    for node in nodes:
         if not isinstance(node, _ALLOWED_NODES):
             raise SimulationError(f"Unsupported syntax in expression '{expr}'.")
+
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            if abs(float(node.value)) > _MAX_NUMERIC_LITERAL_MAGNITUDE:
+                raise SimulationError(
+                    "Numeric literal is too large; reduce constant magnitude in the expression."
+                )
+
         if isinstance(node, ast.Call):
             if not isinstance(node.func, ast.Name) or node.func.id not in _ALLOWED_NAMES:
                 raise SimulationError(f"Use of function '{ast.dump(node.func)}' is not allowed.")
+            arg_count = len(node.args) + len(node.keywords)
+            if arg_count > _MAX_CALL_ARGUMENT_COUNT:
+                raise SimulationError(
+                    f"Function calls are limited to {_MAX_CALL_ARGUMENT_COUNT} arguments."
+                )
+
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Pow):
+            exponent_node = node.right
+            if isinstance(exponent_node, ast.Constant) and isinstance(exponent_node.value, (int, float)):
+                exponent = float(exponent_node.value)
+                if abs(exponent) > _MAX_POW_EXPONENT:
+                    raise SimulationError(
+                        f"Exponent magnitude is too large; keep it at {_MAX_POW_EXPONENT} or below."
+                    )
 
     code = compile(tree, "<expr>", "eval")
 


### PR DESCRIPTION
### Motivation
- Prevent abusive or accidental expensive expressions in the UI simulator by validating AST complexity, numeric literals, exponentiation and call arguments before compiling user-provided expressions.

### Description
- Add safety constants ` _MAX_AST_NODE_COUNT = 200`, `_MAX_NUMERIC_LITERAL_MAGNITUDE = 1_000_000`, `_MAX_POW_EXPONENT = 100`, and `_MAX_CALL_ARGUMENT_COUNT = 4` in `webapp/simulator.py`.
- Extend `_compile_expression` to walk the AST and raise `SimulationError` with user-facing messages when the node count, numeric literal magnitude, exponent literal size (for `Pow`), or call-argument count exceed limits, and preserve existing allowed-node and allowed-function checks.
- Keep evaluation sandboxing behavior and compile only after the AST checks pass.
- Update `tests/test_webapp_simulator.py` with tests that exercise oversized ASTs, large exponents, excessive call arguments, and oversized numeric literals.

### Testing
- Ran `pytest -q tests/test_webapp_simulator.py`, which passed: `5 passed`.
- Attempted to run `pytest -q tests/test_webapp_simulator.py tests/test_simulator.py`, which failed during collection due to an environment missing the `flask` dependency (import error), unrelated to the new logic.
- New tests added are in `tests/test_webapp_simulator.py` and cover oversized ASTs, large exponent payloads, excessive call-arg payloads, and large numeric literals; they succeed in the current test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d179fb55d48328904a7406d4880ebb)