### PR TITLE
Validate non-positive ellipse axes during zone parsing

### DIFF
--- a/nagare_interpreter.py
+++ b/nagare_interpreter.py
@@ -104,7 +104,15 @@ def parse_zones(src: str) -> List[Zone]:
     )
     zones: List[Zone] = []
     for name, cx, cy, a, b in zone_pattern.findall(src):
-        zones.append(Zone(name, float(cx), float(cy), float(a), float(b), ('', '')))
+        cx_val = float(cx)
+        cy_val = float(cy)
+        a_val = float(a)
+        b_val = float(b)
+        if a_val <= 0 or b_val <= 0:
+            raise ValueError(
+                f"Zone '{name}' has non-positive ellipse axes: a={a_val}, b={b_val}"
+            )
+        zones.append(Zone(name, cx_val, cy_val, a_val, b_val, ('', '')))
     return zones
 
 def parse_execute(src: str, zones: Dict[str, Zone]) -> None:

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -27,3 +27,17 @@ def test_parse_execute_raises_for_unknown_zone():
     src = "EXECUTE { prog<missing> { display \"hello\" } }"
     with pytest.raises(ValueError, match="missing"):
         parse_execute(src, {})
+
+
+@pytest.mark.parametrize(
+    ("axis_value", "expected_fragment"),
+    [
+        ("0", "a=0.0, b=1.0"),
+        ("-1", "a=-1.0, b=1.0"),
+    ],
+)
+def test_parse_zones_rejects_non_positive_ellipse_axis(axis_value, expected_fragment):
+    src = f"ZONES {{ badZone {{ Ellipse((0, 0), {axis_value}, 1) }} }}"
+    with pytest.raises(ValueError, match=r"badZone") as exc_info:
+        parse_zones(src)
+    assert expected_fragment in str(exc_info.value)


### PR DESCRIPTION
### Motivation
- Ensure zone definitions with invalid ellipse axes are rejected early to avoid downstream errors during simulation.

### Description
- In `nagare_interpreter.py` added float parsing for `cx`, `cy`, `a`, and `b` and validate that `a` and `b` are strictly positive, raising `ValueError` when not with a message containing the zone name and the parsed axis values.
- Update prevents constructing a `Zone` for invalid ellipses and preserves prior behavior for valid zones.
- Added regression tests in `tests/test_zones.py` using inline `ZONES` script snippets to assert `parse_zones` fails fast for `Ellipse(..., 0, 1)` and `Ellipse(..., -1, 1)` and that the error message includes the expected content.

### Testing
- Ran `pytest -q tests/test_zones.py` and the suite passed with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d179fcd13083289f9d2b1b8922c98a)