### PR TITLE
Default tester runs to overwrite output; add --append option

### DIFF
--- a/tester.c
+++ b/tester.c
@@ -16,6 +16,7 @@
 typedef struct {
     char filepath[BUFFER_SIZE];
     float x0, y0;    
+    bool append_output;
     int result;
 } ThreadData;
 
@@ -73,8 +74,9 @@ int load_data(const char* filepath, ThreadData** out_data) {
 
 void* simulate(void* arg) {
     ThreadData* data = (ThreadData*) arg;
-    
-    FILE *file = fopen(data->filepath, "a");
+
+    const char* file_mode = data->append_output ? "a" : "w";
+    FILE *file = fopen(data->filepath, file_mode);
     if (file == NULL)
         return NULL;    
         
@@ -95,8 +97,26 @@ void* simulate(void* arg) {
 
 
 int main(int argc, char* argv[]) {
-    if (argc < 2) {
-        fprintf(stderr, "usage  tester  input.file\n");
+    bool append_output = false;
+    const char* input_filepath = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--append") == 0) {
+            append_output = true;
+            continue;
+        }
+
+        if (input_filepath == NULL) {
+            input_filepath = argv[i];
+            continue;
+        }
+
+        fprintf(stderr, "usage: tester [--append] input.file\n");
+        return EXIT_FAILURE;
+    }
+
+    if (input_filepath == NULL) {
+        fprintf(stderr, "usage: tester [--append] input.file\n");
         return EXIT_FAILURE;
     }
 
@@ -108,11 +128,15 @@ int main(int argc, char* argv[]) {
     // };
 
     ThreadData* thread_data = NULL;
-    int thread_count = load_data(argv[1], &thread_data);
+    int thread_count = load_data(input_filepath, &thread_data);
     if (thread_count < 0) {
-        fprintf(stderr, "Failed to load thread data from '%s': %s\n", argv[1],
+        fprintf(stderr, "Failed to load thread data from '%s': %s\n", input_filepath,
                 strerror(-thread_count));
         return EXIT_FAILURE;
+    }
+
+    for (int i = 0; i < thread_count; i++) {
+        thread_data[i].append_output = append_output;
     }
 
     pthread_t threads[MAX_THREADS];

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -11,10 +11,10 @@ def build_tester():
     subprocess.run(["make", "tester"], cwd=ROOT, check=True)
 
 
-def run_tester(*args: str) -> subprocess.CompletedProcess[str]:
+def run_tester(*args: str, cwd: Path = ROOT) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [str(ROOT / "tester"), *args],
-        cwd=ROOT,
+        cwd=cwd,
         text=True,
         capture_output=True,
     )
@@ -39,3 +39,37 @@ def test_tester_reports_missing_file(tmp_path):
     assert (
         f"Failed to load thread data from '{missing_file}':" in result.stderr
     )
+
+
+def test_tester_overwrites_output_by_default(tmp_path):
+    input_file = tmp_path / "single_point.txt"
+    input_file.write_text("0.0 3.4e38\n")
+
+    first_run = run_tester(str(input_file), cwd=tmp_path)
+    assert first_run.returncode == 0
+    output_file = next(path for path in tmp_path.glob("*.txt") if path != input_file)
+    first_lines = output_file.read_text().splitlines()
+    assert first_lines
+
+    second_run = run_tester(str(input_file), cwd=tmp_path)
+    assert second_run.returncode == 0
+    second_lines = output_file.read_text().splitlines()
+
+    assert second_lines == first_lines
+
+
+def test_tester_append_flag_accumulates_output(tmp_path):
+    input_file = tmp_path / "single_point.txt"
+    input_file.write_text("0.0 3.4e38\n")
+
+    first_run = run_tester("--append", str(input_file), cwd=tmp_path)
+    assert first_run.returncode == 0
+    output_file = next(path for path in tmp_path.glob("*.txt") if path != input_file)
+    first_lines = output_file.read_text().splitlines()
+    assert first_lines
+
+    second_run = run_tester("--append", str(input_file), cwd=tmp_path)
+    assert second_run.returncode == 0
+    second_lines = output_file.read_text().splitlines()
+
+    assert len(second_lines) == len(first_lines) * 2


### PR DESCRIPTION
### Motivation
- Prevent repeated runs of the `tester` program from accumulating duplicate trajectory lines by default, while preserving legacy append behavior as an option.

### Description
- Change `simulate()` to open per-thread output files with mode chosen from a new `append_output` field so files are overwritten by default (`"w"`) and can be appended with `"a"` when requested.
- Add simple CLI parsing in `main()` to accept an optional `--append` flag and an `input.file` argument, and propagate the append choice into each `ThreadData` entry.
- Add/modify tests in `tests/test_tester.py` to allow running `tester` in a temporary working directory and to assert that repeated default runs overwrite output while `--append` accumulates output.

### Testing
- Built the binary with `make tester` as part of the test fixture and ran `pytest -q tests/test_tester.py`.
- All tests in `tests/test_tester.py` passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17a00b3d48328975f82b0180371d7)