### PR TITLE
Handle ring buffer allocation failures gracefully

### DIFF
--- a/ring.c
+++ b/ring.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <stdatomic.h>
 
 #define WRITER_ITERS 25
 #define READER_ITERS 25
@@ -15,9 +16,11 @@ typedef struct RingBuffer {
     void** buffer;
     size_t elem_size;
     pthread_mutex_t lock;
+    atomic_int shutdown_requested;
 } RingBuffer;
 
 static size_t slot_allocations = 0;
+static atomic_size_t slot_allocation_attempts = 0;
 
 typedef enum DataType {
     INT,
@@ -35,6 +38,8 @@ int create_buffer(RingBuffer* cache, size_t buffer_size, size_t elem_size) {
     cache->capacity = 0;
     cache->buffer = NULL;
     cache->elem_size = elem_size;
+    atomic_store(&cache->shutdown_requested, 0);
+    atomic_store(&slot_allocation_attempts, 0);
 
     if (buffer_size <= 1) {
         fprintf(stderr, "Buffer size should be greater than 1.\n");
@@ -92,17 +97,27 @@ void print_buffer(RingBuffer* cache, DataType type) {
 }
 
 
-void add_to_buffer(RingBuffer* cache, const void* value) {
+int add_to_buffer(RingBuffer* cache, const void* value) {
     pthread_mutex_lock(&cache->lock);
 
     void* slot = cache->buffer[cache->idx];
 
     if (slot == NULL) {
+        size_t allocation_attempt = atomic_fetch_add(&slot_allocation_attempts, 1) + 1;
+#ifdef RING_TEST_ALLOC_FAIL_AT
+        if (allocation_attempt == (size_t)RING_TEST_ALLOC_FAIL_AT) {
+            pthread_mutex_unlock(&cache->lock);
+            fprintf(stderr, "Injected slot allocation failure at attempt %zu.\n", allocation_attempt);
+            atomic_store(&cache->shutdown_requested, 1);
+            return -1;
+        }
+#endif
         slot = malloc(cache->elem_size);
         if (!slot) {
             pthread_mutex_unlock(&cache->lock);
             fprintf(stderr, "Failed to allocate ring buffer slot.\n");
-            exit(EXIT_FAILURE);
+            atomic_store(&cache->shutdown_requested, 1);
+            return -1;
         }
         cache->buffer[cache->idx] = slot;
         ++slot_allocations;
@@ -112,6 +127,7 @@ void add_to_buffer(RingBuffer* cache, const void* value) {
     cache->idx = ( cache->idx + 1 ) % cache->capacity;
 
     pthread_mutex_unlock(&cache->lock);
+    return 0;
 }
 
 void destroy_buffer(RingBuffer* cache) {
@@ -150,16 +166,25 @@ int main() {
     pthread_join(w2, NULL);
     pthread_join(r, NULL);
 
+    int should_fail = atomic_load(&cache.shutdown_requested);
     destroy_buffer(&cache);
+    assert(slot_allocations == 0);
 
-    return 0;
+    return should_fail ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 
 void* writer(void* arg) {
     RingBuffer* c = (RingBuffer*)arg;
     for (int i = 0; i < WRITER_ITERS; ++i) {
+        if (atomic_load(&c->shutdown_requested)) {
+            break;
+        }
         int value = i;
-        add_to_buffer(c, &value);
+        if (add_to_buffer(c, &value) != 0) {
+            fprintf(stderr, "Writer thread stopping due to add_to_buffer failure.\n");
+            atomic_store(&c->shutdown_requested, 1);
+            break;
+        }
         usleep(1000);
     }
     return NULL;
@@ -168,6 +193,9 @@ void* writer(void* arg) {
 void* reader(void* arg) {
     RingBuffer* c = (RingBuffer*)arg;
     for (int i = 0; i < READER_ITERS; ++i) {
+        if (atomic_load(&c->shutdown_requested)) {
+            break;
+        }
         print_buffer(c, INT);
         usleep(1000);
     }

--- a/tests/test_ring_buffer.py
+++ b/tests/test_ring_buffer.py
@@ -39,3 +39,28 @@ def test_ring_buffer_thread_synchronization(tmp_path):
     assert any(token != "NULL" for token in tokens)
 
     assert len(tokens) == capacity * reader_iters
+
+
+def test_ring_buffer_allocation_failure_is_graceful(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    executable = tmp_path / "ring_fail"
+
+    compile_cmd = [
+        "gcc",
+        "-O2",
+        "-Wall",
+        "-DRING_TEST_ALLOC_FAIL_AT=1",
+        "ring.c",
+        "-o",
+        str(executable),
+        "-lpthread",
+    ]
+    subprocess.run(compile_cmd, cwd=repo_root, check=True)
+
+    run = subprocess.run(
+        [str(executable)], cwd=repo_root, capture_output=True, text=True
+    )
+
+    assert run.returncode != 0
+    assert "Injected slot allocation failure" in run.stderr
+    assert "Writer thread stopping due to add_to_buffer failure." in run.stderr


### PR DESCRIPTION
### Motivation

- Prevent the process from hard-aborting on a slot allocation failure in the ring buffer and ensure resources are still cleaned up.
- Allow writer/reader threads to stop cleanly when an allocation error occurs so the program can shutdown deterministically.
- Provide a deterministic failure-injection for testing to verify the graceful shutdown path.

### Description

- Change `add_to_buffer` signature to `int` and return `0` on success or `-1` on allocation/error instead of calling `exit()`.
- Add an `atomic_int shutdown_requested` to `RingBuffer` and `atomic_size_t slot_allocation_attempts` so threads can observe a shutdown request and stop cleanly, and `main` can return failure after joining threads while still calling `destroy_buffer`.
- Add a macro-guarded failure-injection (`RING_TEST_ALLOC_FAIL_AT`) that forces a slot allocation failure and logs `Injected slot allocation failure` for deterministic tests.
- Add `test_ring_buffer_allocation_failure_is_graceful` which compiles `ring.c` with `-DRING_TEST_ALLOC_FAIL_AT=1` and asserts the process exits non-zero and emits the expected stderr messages.

### Testing

- Ran `pytest -q tests/test_ring_buffer.py` which executed the original synchronization test and the new failure-injection test and reported `2 passed`.
- The new test compiles the instrumented binary and asserts `run.returncode != 0` and presence of both `Injected slot allocation failure` and `Writer thread stopping due to add_to_buffer failure.` in stderr, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17a039ed883289f56438d4667347b)