### PR TITLE
Add static GitHub Pages Nagare runtime playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,31 @@ Feel free to submit pull requests for bug fixes, new features, or additional sim
 ## License
 This project is licensed under the MIT License. See `LICENSE` for details.
 
+
+## GitHub Pages Runtime Playground
+
+A serverless Nagare runtime is available in `docs/` for deployment with GitHub Pages.
+It runs entirely in the browser, so no Flask server or Python process is required after
+publishing the static files.
+
+### Features
+- Draw ellipse zones directly on the canvas and automatically insert them into the
+  `ZONES` block as `Ellipse((cx, cy), a, b)` definitions.
+- Click to place entities, erase entities or drawn zones, and animate the resulting
+  Nagare program path.
+- Parse and run the repository's lightweight Nagare subset: `program { x_expr, y_expr }`,
+  ellipse zones, `display "message"`, and `finish` actions.
+
+### Deploying on GitHub Pages
+1. Commit the repository with the `docs/` directory present.
+2. In the GitHub repository settings, choose **Pages**.
+3. Set the source to **Deploy from a branch**, select the desired branch, and choose
+   `/docs` as the publishing folder.
+4. Save the configuration. GitHub Pages will serve `docs/index.html` as the static
+   Nagare runtime playground.
+
+You can also preview it locally without any build step:
+```bash
+python3 -m http.server 8000 --directory docs
+```
+Then open <http://localhost:8000>.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nagare Runtime Playground</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div>
+        <p class="eyebrow">Static GitHub Pages runtime</p>
+        <h1>Nagare Runtime Playground</h1>
+        <p>
+          Draw zones directly on the canvas, place entities, edit a Nagare program, and run it entirely in your browser.
+        </p>
+      </div>
+      <div class="hero-actions">
+        <button id="loadExample" type="button">Load example</button>
+        <button id="runProgram" type="button" class="primary">Run Nagare</button>
+      </div>
+    </header>
+
+    <main class="workspace">
+      <section class="panel editor-panel" aria-labelledby="program-heading">
+        <div class="panel-header">
+          <div>
+            <h2 id="program-heading">Nagare program</h2>
+            <p>
+              Supported: <code>program { expr, expr }</code>, ellipse zones, <code>display</code>, and <code>finish</code> actions.
+            </p>
+          </div>
+        </div>
+        <textarea id="programSource" spellcheck="false" aria-label="Nagare source code"></textarea>
+        <div class="settings-grid">
+          <label>
+            Steps
+            <input id="stepLimit" type="number" min="1" max="2000" value="160" />
+          </label>
+          <label>
+            Frame delay (ms)
+            <input id="frameDelay" type="number" min="0" max="1000" value="70" />
+          </label>
+        </div>
+        <div id="status" role="status" aria-live="polite"></div>
+      </section>
+
+      <section class="stage panel" aria-labelledby="canvas-heading">
+        <div class="panel-header stage-header">
+          <div>
+            <h2 id="canvas-heading">Canvas</h2>
+            <p>Choose a tool, then click or drag on the canvas. Drawn zones are inserted into the program.</p>
+          </div>
+          <div class="toolbox" role="toolbar" aria-label="Canvas tools">
+            <button type="button" class="tool active" data-tool="entity">Entity</button>
+            <button type="button" class="tool" data-tool="ellipse">Ellipse</button>
+            <button type="button" class="tool" data-tool="erase">Erase</button>
+            <button id="resetRuntime" type="button">Reset</button>
+          </div>
+        </div>
+        <canvas id="runtimeCanvas" width="900" height="620" aria-label="Nagare drawing canvas"></canvas>
+        <div class="legend" aria-label="Canvas legend">
+          <span><i class="entity-dot"></i>Entity</span>
+          <span><i class="zone-dot"></i>Drawn / parsed zone</span>
+          <span><i class="path-dot"></i>Runtime path</span>
+        </div>
+      </section>
+
+      <aside class="panel side-panel" aria-labelledby="runtime-heading">
+        <h2 id="runtime-heading">Runtime output</h2>
+        <section>
+          <h3>Entities</h3>
+          <ul id="entityList" class="data-list"></ul>
+        </section>
+        <section>
+          <h3>Zones</h3>
+          <ul id="zoneList" class="data-list"></ul>
+        </section>
+        <section>
+          <h3>Events</h3>
+          <ul id="eventLog" class="data-list log"></ul>
+        </section>
+      </aside>
+    </main>
+
+    <script src="./runtime.js" type="module"></script>
+  </body>
+</html>

--- a/docs/runtime.js
+++ b/docs/runtime.js
@@ -1,0 +1,536 @@
+const programSource = document.getElementById('programSource');
+const runButton = document.getElementById('runProgram');
+const loadExampleButton = document.getElementById('loadExample');
+const resetButton = document.getElementById('resetRuntime');
+const stepLimitInput = document.getElementById('stepLimit');
+const frameDelayInput = document.getElementById('frameDelay');
+const statusBox = document.getElementById('status');
+const canvas = document.getElementById('runtimeCanvas');
+const ctx = canvas.getContext('2d');
+const zoneList = document.getElementById('zoneList');
+const entityList = document.getElementById('entityList');
+const eventLog = document.getElementById('eventLog');
+const toolButtons = [...document.querySelectorAll('.tool')];
+
+const EXAMPLE = `BEGIN {
+  program spiral { x + 0.08 - y * 0.08, y + x * 0.08 }
+}
+
+ZONES {
+  hello { Ellipse((1.25, 0.25), 0.75, 0.55) }
+  done { Ellipse((2.25, 1.2), 0.65, 0.65) }
+}
+
+EXECUTE {
+  spiral<hello> { display "Hello from a drawn zone" }
+  spiral<done> { finish }
+}`;
+
+const state = {
+  tool: 'entity',
+  scale: 80,
+  entities: [{ id: 'entity-1', x: 0, y: 0 }],
+  entityCounter: 2,
+  drawnZones: [],
+  zoneCounter: 1,
+  parsedZones: [],
+  paths: new Map(),
+  currentFrame: 0,
+  frames: [],
+  animationTimer: null,
+  dragStart: null,
+  dragCurrent: null,
+};
+
+const allowedFunctions = {
+  sin: Math.sin,
+  cos: Math.cos,
+  tan: Math.tan,
+  asin: Math.asin,
+  acos: Math.acos,
+  atan: Math.atan,
+  atan2: Math.atan2,
+  sqrt: Math.sqrt,
+  abs: Math.abs,
+  log: Math.log,
+  exp: Math.exp,
+  min: Math.min,
+  max: Math.max,
+  hypot: Math.hypot,
+};
+
+function setStatus(message, kind = '') {
+  statusBox.textContent = message;
+  statusBox.className = kind;
+}
+
+function setTool(tool) {
+  state.tool = tool;
+  toolButtons.forEach((button) => button.classList.toggle('active', button.dataset.tool === tool));
+}
+
+toolButtons.forEach((button) => button.addEventListener('click', () => setTool(button.dataset.tool)));
+
+function cssCanvasSize() {
+  const ratio = window.devicePixelRatio || 1;
+  return { width: canvas.width / ratio, height: canvas.height / ratio };
+}
+
+function resizeCanvas() {
+  const ratio = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+  const width = Math.max(640, Math.round(rect.width || 900));
+  const height = Math.max(420, Math.round(width * 0.68));
+  canvas.width = width * ratio;
+  canvas.height = height * ratio;
+  ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+  draw();
+}
+
+function worldToCanvas(x, y) {
+  const { width, height } = cssCanvasSize();
+  return { x: width / 2 + x * state.scale, y: height / 2 - y * state.scale };
+}
+
+function canvasToWorld(clientX, clientY) {
+  const rect = canvas.getBoundingClientRect();
+  const { width, height } = cssCanvasSize();
+  return {
+    x: (clientX - rect.left - width / 2) / state.scale,
+    y: (height / 2 - (clientY - rect.top)) / state.scale,
+  };
+}
+
+function makeSafeExpression(expr) {
+  if (!expr || !expr.trim()) throw new Error('Program expressions cannot be empty.');
+  if (expr.length > 180) throw new Error(`Expression is too long: ${expr}`);
+  if (!/^[\d\sxytepiPI.,_+\-*/%()^A-Za-z]+$/.test(expr)) {
+    throw new Error(`Unsupported characters in expression: ${expr}`);
+  }
+  const jsExpr = expr.replace(/\bpi\b/gi, 'PI').replace(/\be\b/g, 'E').replace(/\^/g, '**');
+  const names = [...jsExpr.matchAll(/[A-Za-z_]\w*/g)].map((match) => match[0]);
+  const allowed = new Set(['x', 'y', 't', 'PI', 'E', ...Object.keys(allowedFunctions)]);
+  const unknown = names.find((name) => !allowed.has(name));
+  if (unknown) throw new Error(`Unknown identifier '${unknown}' in expression '${expr}'.`);
+  const fn = new Function('x', 'y', 't', 'PI', 'E', ...Object.keys(allowedFunctions), `return (${jsExpr});`);
+  return (x, y, t) => {
+    const value = fn(x, y, t, Math.PI, Math.E, ...Object.values(allowedFunctions));
+    if (!Number.isFinite(value)) throw new Error(`Expression '${expr}' produced a non-finite value.`);
+    return Number(value);
+  };
+}
+
+function parseProgramExpressions(source) {
+  const header = source.match(/program\s+(?:\w+\s+)?\{/im);
+  if (!header) throw new Error('Could not find a program { x-expression, y-expression } block.');
+  const bodyStart = header.index + header[0].length;
+  let depth = 0;
+  for (let i = bodyStart; i < source.length; i += 1) {
+    const char = source[i];
+    if (char === '(') depth += 1;
+    if (char === ')') depth -= 1;
+    if (char === '}' && depth === 0) {
+      const body = source.slice(bodyStart, i);
+      let commaIndex = -1;
+      let commaDepth = 0;
+      for (let j = 0; j < body.length; j += 1) {
+        const innerChar = body[j];
+        if (innerChar === '(') commaDepth += 1;
+        if (innerChar === ')') commaDepth -= 1;
+        if (innerChar === ',' && commaDepth === 0) {
+          commaIndex = j;
+          break;
+        }
+      }
+      if (commaIndex < 0) throw new Error('Program block must contain two expressions separated by a comma.');
+      return [body.slice(0, commaIndex).trim(), body.slice(commaIndex + 1).trim()];
+    }
+  }
+  throw new Error('Program block is missing its closing brace.');
+}
+
+function parseNagare(source) {
+  const [fxExpr, fyExpr] = parseProgramExpressions(source);
+
+  const zoneMap = new Map();
+  const zonePattern = /(\w+)\s*\{\s*Ellipse\s*\(\s*\(\s*([^,()]+)\s*,\s*([^()]+?)\s*\)\s*,\s*([^,()]+)\s*,\s*([^()]+?)\s*\)\s*\}/gim;
+  let zoneMatch;
+  while ((zoneMatch = zonePattern.exec(source)) !== null) {
+    const [, name, cx, cy, a, b] = zoneMatch;
+    const zone = { id: `source-${name}`, label: name, cx: Number(cx), cy: Number(cy), a: Number(a), b: Number(b), action: null };
+    if (![zone.cx, zone.cy, zone.a, zone.b].every(Number.isFinite) || zone.a <= 0 || zone.b <= 0) {
+      throw new Error(`Zone '${name}' has invalid ellipse parameters.`);
+    }
+    zoneMap.set(name, zone);
+  }
+
+  const executePattern = /\w+<([A-Za-z_]\w*)>\s*\{\s*(display\s+"([^"]*)"|finish)\s*\}/gim;
+  let executeMatch;
+  while ((executeMatch = executePattern.exec(source)) !== null) {
+    const [, zoneName, actionText, message] = executeMatch;
+    const zone = zoneMap.get(zoneName);
+    if (!zone) throw new Error(`EXECUTE references unknown zone '${zoneName}'.`);
+    zone.action = actionText.startsWith('display') ? { type: 'display', message } : { type: 'finish' };
+  }
+
+  return {
+    fx: makeSafeExpression(fxExpr),
+    fy: makeSafeExpression(fyExpr),
+    zones: [...zoneMap.values()],
+  };
+}
+
+function zoneContains(zone, x, y) {
+  const dx = (x - zone.cx) / zone.a;
+  const dy = (y - zone.cy) / zone.b;
+  return dx * dx + dy * dy <= 1;
+}
+
+function runNagare(source, initialEntities, stepLimit) {
+  const parsed = parseNagare(source);
+  state.parsedZones = parsed.zones;
+  const entities = initialEntities.map((entity) => ({ ...entity }));
+  const frames = [{ step: 0, entities: entities.map((entity) => ({ ...entity })) }];
+  const events = [];
+  const triggered = new Set();
+  let finished = false;
+
+  for (let step = 1; step <= stepLimit && !finished; step += 1) {
+    entities.forEach((entity) => {
+      const x = parsed.fx(entity.x, entity.y, step - 1);
+      const y = parsed.fy(entity.x, entity.y, step - 1);
+      entity.x = x;
+      entity.y = y;
+    });
+
+    frames.push({ step, entities: entities.map((entity) => ({ ...entity })) });
+
+    for (const entity of entities) {
+      for (const zone of parsed.zones) {
+        const key = `${entity.id}:${zone.id}`;
+        if (zone.action && !triggered.has(key) && zoneContains(zone, entity.x, entity.y)) {
+          triggered.add(key);
+          const event = { step, entityId: entity.id, zoneLabel: zone.label, ...zone.action };
+          events.push(event);
+          if (zone.action.type === 'finish') finished = true;
+        }
+      }
+    }
+  }
+
+  return { frames, events, finished };
+}
+
+function ellipseToNagare(zone) {
+  return `  ${zone.label} { Ellipse((${format(zone.cx)}, ${format(zone.cy)}), ${format(zone.a)}, ${format(zone.b)}) }`;
+}
+
+function format(value) {
+  return Number(value.toFixed(3)).toString();
+}
+
+function insertDrawnZone(zone) {
+  const source = programSource.value;
+  const zoneLine = ellipseToNagare(zone);
+  const zonesMatch = source.match(/ZONES\s*\{[\s\S]*?\}/i);
+  if (zonesMatch) {
+    const insertAt = zonesMatch.index + zonesMatch[0].lastIndexOf('}');
+    programSource.value = `${source.slice(0, insertAt).trimEnd()}\n${zoneLine}\n${source.slice(insertAt)}`;
+    return;
+  }
+  programSource.value = `${source.trim()}\n\nZONES {\n${zoneLine}\n}\n`;
+}
+
+function addEntity(point) {
+  state.entities.push({ id: `entity-${state.entityCounter}`, x: point.x, y: point.y });
+  state.entityCounter += 1;
+  clearRuntimeData();
+  draw();
+  renderLists();
+}
+
+function addDrawnZone(start, end) {
+  const cx = (start.x + end.x) / 2;
+  const cy = (start.y + end.y) / 2;
+  const a = Math.max(Math.abs(end.x - start.x) / 2, 0.08);
+  const b = Math.max(Math.abs(end.y - start.y) / 2, 0.08);
+  const zone = { id: `drawn-zone-${state.zoneCounter}`, label: `drawn${state.zoneCounter}`, cx, cy, a, b };
+  state.zoneCounter += 1;
+  state.drawnZones.push(zone);
+  insertDrawnZone(zone);
+  clearRuntimeData();
+  renderLists();
+  draw();
+}
+
+function eraseAt(point) {
+  const entityIndex = state.entities.findIndex((entity) => Math.hypot(entity.x - point.x, entity.y - point.y) < 0.16);
+  if (entityIndex >= 0) {
+    state.entities.splice(entityIndex, 1);
+  } else {
+    const zoneIndex = state.drawnZones.findIndex((zone) => zoneContains(zone, point.x, point.y));
+    if (zoneIndex >= 0) state.drawnZones.splice(zoneIndex, 1);
+  }
+  clearRuntimeData();
+  renderLists();
+  draw();
+}
+
+function clearRuntimeData() {
+  window.clearTimeout(state.animationTimer);
+  state.animationTimer = null;
+  state.frames = [];
+  state.paths = new Map();
+  state.currentFrame = 0;
+}
+
+function canvasPointerDown(event) {
+  const point = canvasToWorld(event.clientX, event.clientY);
+  if (state.tool === 'entity') {
+    addEntity(point);
+  } else if (state.tool === 'erase') {
+    eraseAt(point);
+  } else {
+    state.dragStart = point;
+    state.dragCurrent = point;
+    canvas.setPointerCapture(event.pointerId);
+    draw();
+  }
+}
+
+function canvasPointerMove(event) {
+  if (!state.dragStart || state.tool !== 'ellipse') return;
+  state.dragCurrent = canvasToWorld(event.clientX, event.clientY);
+  draw();
+}
+
+function canvasPointerUp(event) {
+  if (!state.dragStart || state.tool !== 'ellipse') return;
+  const end = canvasToWorld(event.clientX, event.clientY);
+  addDrawnZone(state.dragStart, end);
+  state.dragStart = null;
+  state.dragCurrent = null;
+  canvas.releasePointerCapture(event.pointerId);
+}
+
+function drawGrid() {
+  const { width, height } = cssCanvasSize();
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = '#07111f';
+  ctx.fillRect(0, 0, width, height);
+  ctx.strokeStyle = 'rgba(148, 163, 184, 0.12)';
+  ctx.lineWidth = 1;
+  const grid = state.scale;
+  for (let x = width / 2 % grid; x < width; x += grid) {
+    ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, height); ctx.stroke();
+  }
+  for (let y = height / 2 % grid; y < height; y += grid) {
+    ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(width, y); ctx.stroke();
+  }
+  ctx.strokeStyle = 'rgba(226, 232, 240, 0.28)';
+  const origin = worldToCanvas(0, 0);
+  ctx.beginPath(); ctx.moveTo(0, origin.y); ctx.lineTo(width, origin.y); ctx.moveTo(origin.x, 0); ctx.lineTo(origin.x, height); ctx.stroke();
+}
+
+function drawEllipse(zone, color = 'rgba(34, 211, 238, 0.92)', fill = 'rgba(34, 211, 238, 0.08)') {
+  const center = worldToCanvas(zone.cx, zone.cy);
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.fillStyle = fill;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.ellipse(center.x, center.y, zone.a * state.scale, zone.b * state.scale, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.fillStyle = color;
+  ctx.font = '12px sans-serif';
+  ctx.fillText(zone.label, center.x + 8, center.y - 8);
+  ctx.restore();
+}
+
+function drawPaths() {
+  ctx.save();
+  ctx.lineWidth = 2.5;
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+  ctx.strokeStyle = 'rgba(167, 139, 250, 0.78)';
+  state.paths.forEach((points) => {
+    ctx.beginPath();
+    points.slice(0, state.currentFrame + 1).forEach((point, index) => {
+      const canvasPoint = worldToCanvas(point.x, point.y);
+      if (index === 0) ctx.moveTo(canvasPoint.x, canvasPoint.y);
+      else ctx.lineTo(canvasPoint.x, canvasPoint.y);
+    });
+    ctx.stroke();
+  });
+  ctx.restore();
+}
+
+function drawEntities(entities = state.entities) {
+  entities.forEach((entity) => {
+    const point = worldToCanvas(entity.x, entity.y);
+    ctx.save();
+    ctx.fillStyle = '#fb923c';
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.75)';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(point.x, point.y, 6, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+    ctx.restore();
+  });
+}
+
+function drawDragPreview() {
+  if (!state.dragStart || !state.dragCurrent) return;
+  const preview = {
+    label: 'preview',
+    cx: (state.dragStart.x + state.dragCurrent.x) / 2,
+    cy: (state.dragStart.y + state.dragCurrent.y) / 2,
+    a: Math.max(Math.abs(state.dragCurrent.x - state.dragStart.x) / 2, 0.08),
+    b: Math.max(Math.abs(state.dragCurrent.y - state.dragStart.y) / 2, 0.08),
+  };
+  drawEllipse(preview, 'rgba(253, 224, 71, 0.95)', 'rgba(253, 224, 71, 0.08)');
+}
+
+function draw() {
+  drawGrid();
+  const parsedZonesById = new Set(state.parsedZones.map((zone) => zone.id));
+  state.parsedZones.forEach((zone) => drawEllipse(zone));
+  state.drawnZones.filter((zone) => !parsedZonesById.has(`source-${zone.label}`)).forEach((zone) => drawEllipse(zone, 'rgba(94, 234, 212, 0.65)'));
+  drawDragPreview();
+  if (state.frames.length) {
+    drawPaths();
+    drawEntities(state.frames[state.currentFrame].entities);
+  } else {
+    drawEntities();
+  }
+}
+
+function renderLists(events = []) {
+  entityList.innerHTML = '';
+  (state.frames[state.currentFrame]?.entities || state.entities).forEach((entity) => {
+    const item = document.createElement('li');
+    item.innerHTML = `<strong>${entity.id}</strong> (${format(entity.x)}, ${format(entity.y)})`;
+    entityList.appendChild(item);
+  });
+  if (!entityList.children.length) entityList.innerHTML = '<li>No entities yet.</li>';
+
+  zoneList.innerHTML = '';
+  const zones = state.parsedZones.length ? state.parsedZones : state.drawnZones;
+  zones.forEach((zone) => {
+    const item = document.createElement('li');
+    item.innerHTML = `<strong>${zone.label}</strong> center=(${format(zone.cx)}, ${format(zone.cy)}), axes=(${format(zone.a)}, ${format(zone.b)})`;
+    zoneList.appendChild(item);
+  });
+  if (!zoneList.children.length) zoneList.innerHTML = '<li>No zones yet. Draw an ellipse or add one to the source.</li>';
+
+  eventLog.innerHTML = '';
+  events.forEach((event) => {
+    const item = document.createElement('li');
+    item.className = event.type;
+    item.textContent = event.type === 'display'
+      ? `${event.entityId} displayed "${event.message}" in ${event.zoneLabel} at step ${event.step}`
+      : `${event.entityId} finished in ${event.zoneLabel} at step ${event.step}`;
+    eventLog.appendChild(item);
+  });
+  if (!eventLog.children.length) eventLog.innerHTML = '<li>No events recorded.</li>';
+}
+
+function preparePaths(frames) {
+  const paths = new Map();
+  frames[0].entities.forEach((entity) => paths.set(entity.id, []));
+  frames.forEach((frame) => {
+    frame.entities.forEach((entity) => paths.get(entity.id)?.push({ x: entity.x, y: entity.y }));
+  });
+  state.paths = paths;
+}
+
+function animate() {
+  draw();
+  renderLists(state.lastEvents || []);
+  if (state.currentFrame >= state.frames.length - 1) return;
+  state.currentFrame += 1;
+  state.animationTimer = window.setTimeout(animate, Number(frameDelayInput.value) || 0);
+}
+
+function runProgram() {
+  try {
+    clearRuntimeData();
+    if (!state.entities.length) throw new Error('Add at least one entity before running.');
+    const stepLimit = Number(stepLimitInput.value);
+    if (!Number.isInteger(stepLimit) || stepLimit < 1 || stepLimit > 2000) throw new Error('Step limit must be between 1 and 2000.');
+    const result = runNagare(programSource.value, state.entities, stepLimit);
+    state.frames = result.frames;
+    state.lastEvents = result.events;
+    state.currentFrame = 0;
+    preparePaths(result.frames);
+    renderLists(result.events);
+    setStatus(`Ran ${result.frames.length - 1} step(s)${result.finished ? ' and reached finish.' : '.'}`, 'ok');
+    animate();
+  } catch (error) {
+    clearRuntimeData();
+    state.parsedZones = [];
+    setStatus(error.message, 'error');
+    renderLists([]);
+    draw();
+  }
+}
+
+function loadExample() {
+  clearRuntimeData();
+  state.entities = [{ id: 'entity-1', x: 0, y: 0 }];
+  state.entityCounter = 2;
+  state.drawnZones = [];
+  state.zoneCounter = 1;
+  state.parsedZones = [];
+  state.lastEvents = [];
+  programSource.value = EXAMPLE;
+  setStatus('Loaded the browser-only Nagare example. Drag an ellipse to add a zone.', 'ok');
+  try {
+    state.parsedZones = parseNagare(programSource.value).zones;
+  } catch (_) {
+    state.parsedZones = [];
+  }
+  renderLists([]);
+  draw();
+}
+
+function resetRuntime() {
+  clearRuntimeData();
+  state.entities = [];
+  state.entityCounter = 1;
+  state.drawnZones = [];
+  state.zoneCounter = 1;
+  state.parsedZones = [];
+  state.lastEvents = [];
+  setStatus('Runtime reset. Add an entity and draw zones to begin.');
+  renderLists([]);
+  draw();
+}
+
+canvas.addEventListener('pointerdown', canvasPointerDown);
+canvas.addEventListener('pointermove', canvasPointerMove);
+canvas.addEventListener('pointerup', canvasPointerUp);
+canvas.addEventListener('pointercancel', () => { state.dragStart = null; state.dragCurrent = null; draw(); });
+runButton.addEventListener('click', runProgram);
+loadExampleButton.addEventListener('click', loadExample);
+resetButton.addEventListener('click', resetRuntime);
+programSource.addEventListener('input', () => {
+  try {
+    state.parsedZones = parseNagare(programSource.value).zones;
+    setStatus('Program parsed. Ready to run.', 'ok');
+  } catch (error) {
+    state.parsedZones = [];
+    setStatus(error.message, 'error');
+  }
+  renderLists(state.lastEvents || []);
+  draw();
+});
+window.addEventListener('resize', resizeCanvas);
+
+programSource.value = EXAMPLE;
+try { state.parsedZones = parseNagare(programSource.value).zones; } catch (_) { state.parsedZones = []; }
+resizeCanvas();
+renderLists([]);
+setStatus('Ready. Click to add entities, drag with the Ellipse tool to draw zones, then run Nagare.');

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,157 @@
+:root {
+  color-scheme: dark;
+  --bg: #08111f;
+  --panel: rgba(15, 23, 42, 0.86);
+  --panel-strong: rgba(15, 23, 42, 0.96);
+  --border: rgba(148, 163, 184, 0.22);
+  --text: #e5eefc;
+  --muted: #9fb0ca;
+  --accent: #22d3ee;
+  --accent-2: #a78bfa;
+  --danger: #fb7185;
+  --success: #86efac;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 12% 10%, rgba(34, 211, 238, 0.22), transparent 28rem),
+    radial-gradient(circle at 86% 0%, rgba(167, 139, 250, 0.22), transparent 26rem),
+    var(--bg);
+  color: var(--text);
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: center;
+  padding: 1.5rem clamp(1rem, 4vw, 3rem);
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(135deg, rgba(8, 17, 31, 0.92), rgba(30, 41, 59, 0.7));
+}
+
+.eyebrow {
+  margin: 0 0 0.25rem;
+  color: var(--accent);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+}
+
+h1, h2, h3, p { margin-top: 0; }
+h1 { margin-bottom: 0.5rem; font-size: clamp(1.8rem, 4vw, 3.2rem); }
+h2 { margin-bottom: 0.35rem; }
+h3 { color: var(--muted); font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.05em; }
+p { color: var(--muted); line-height: 1.55; }
+code { color: #fef08a; }
+
+button, input, textarea {
+  border: 1px solid var(--border);
+  border-radius: 0.7rem;
+  color: var(--text);
+  background: rgba(15, 23, 42, 0.84);
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+  padding: 0.65rem 0.9rem;
+  font-weight: 800;
+  transition: transform 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+button:hover { transform: translateY(-1px); border-color: rgba(34, 211, 238, 0.8); }
+button.primary, .tool.active { background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #07111f; border: 0; }
+button:disabled { cursor: wait; opacity: 0.65; transform: none; }
+
+.hero-actions, .toolbox, .legend { display: flex; flex-wrap: wrap; gap: 0.65rem; align-items: center; }
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.9fr) minmax(460px, 1.4fr) minmax(280px, 0.7fr);
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.26);
+}
+
+.panel-header { display: flex; justify-content: space-between; gap: 1rem; align-items: start; }
+.editor-panel, .side-panel { display: flex; flex-direction: column; gap: 1rem; }
+
+textarea {
+  width: 100%;
+  min-height: 29rem;
+  resize: vertical;
+  padding: 1rem;
+  line-height: 1.5;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  background: rgba(2, 6, 23, 0.72);
+}
+
+.settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem; }
+label { display: flex; flex-direction: column; gap: 0.35rem; color: var(--muted); font-weight: 700; }
+input { padding: 0.6rem 0.7rem; }
+
+.stage { min-width: 0; }
+.stage-header { align-items: center; }
+#runtimeCanvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  min-height: 420px;
+  background: #07111f;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.9rem;
+  touch-action: none;
+}
+
+.legend { color: var(--muted); margin-top: 0.75rem; font-size: 0.92rem; }
+.legend i { display: inline-block; width: 0.9rem; height: 0.9rem; border-radius: 999px; margin-right: 0.35rem; vertical-align: -0.12rem; }
+.entity-dot { background: #fb923c; }
+.zone-dot { background: var(--accent); }
+.path-dot { background: var(--accent-2); }
+
+.data-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.data-list li {
+  padding: 0.65rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.055);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: var(--muted);
+}
+.data-list strong { color: var(--text); }
+.log li.display { border-color: rgba(134, 239, 172, 0.35); color: var(--success); }
+.log li.finish { border-color: rgba(251, 146, 60, 0.35); color: #fdba74; }
+
+#status { min-height: 1.5rem; color: var(--muted); font-weight: 700; }
+#status.error { color: var(--danger); }
+#status.ok { color: var(--success); }
+
+@media (max-width: 1180px) {
+  .workspace { grid-template-columns: 1fr; }
+  textarea { min-height: 22rem; }
+}
+
+@media (max-width: 720px) {
+  .hero { flex-direction: column; align-items: stretch; }
+  .settings-grid { grid-template-columns: 1fr; }
+}

--- a/tests/test_github_pages_runtime.py
+++ b/tests/test_github_pages_runtime.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+DOCS = Path(__file__).resolve().parents[1] / "docs"
+
+
+def test_github_pages_runtime_uses_relative_static_assets():
+    index = (DOCS / "index.html").read_text()
+
+    assert 'href="./style.css"' in index
+    assert 'src="./runtime.js"' in index
+    assert '/static/' not in index
+
+
+def test_github_pages_runtime_exposes_drawing_and_execution_controls():
+    index = (DOCS / "index.html").read_text()
+    runtime = (DOCS / "runtime.js").read_text()
+
+    assert 'data-tool="ellipse"' in index
+    assert 'id="runProgram"' in index
+    assert 'function parseNagare' in runtime
+    assert 'function runNagare' in runtime
+    assert 'function addDrawnZone' in runtime


### PR DESCRIPTION
### Motivation
- Provide a browser-only Nagare runtime so users can draw zones and run Nagare programs without a server, suitable for GitHub Pages deployment.
- Make it easy to share interactive examples and to edit/insert drawn zones directly into a Nagare program in the browser.

### Description
- Added a static runtime under `docs/`: `docs/index.html`, `docs/runtime.js`, and `docs/style.css` that implement an editor, canvas tools, run controls, and runtime output panes.
- Implemented client-side parsing and execution (`parseNagare`, `parseProgramExpressions`, `makeSafeExpression`, `runNagare`) that support `program { expr, expr }`, ellipse `ZONES`, `display` messages, and `finish` actions with safe expression evaluation.
- Implemented canvas interactions to place entities, draw ellipse zones (which are automatically inserted into the `ZONES` block), erase drawn items, animate trajectories, and log events.
- Updated `README.md` with GitHub Pages deployment and local preview instructions and added `tests/test_github_pages_runtime.py` to assert relative asset paths and presence of runtime hooks.

### Testing
- Ran `node --check docs/runtime.js` to validate the runtime script (passed).
- Ran `pytest -q` (installed missing `flask` dependency when collection initially failed) and all tests passed (`31 passed`).
- Served the `docs/` folder with `python -m http.server --directory docs` and verified with `curl -I http://127.0.0.1:8000/` and by fetching the top of `runtime.js` (HTTP 200 and content present).
- Note: an initial test collection error was due to a missing `flask` package which was installed and resolved before the final test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde152bc0c8328a27d6a84c35c3403)